### PR TITLE
Honor the `new_tab` setting

### DIFF
--- a/templates/macros/lists.html
+++ b/templates/macros/lists.html
@@ -6,7 +6,7 @@
     <ul>
         {% for item in config.extra.lists.connect %}
         <li>
-            <a href="{{ item.url }}">{{ item.text }}</a>
+            <a href="{{ item.url }}" {% if item.new_tab %}target="_blank"{% endif %}>{{ item.text }}</a>
         </li>
         {% endfor %}
     </ul>
@@ -22,7 +22,7 @@
     <ul>
         {% for item in config.extra.lists.social %}
         <li>
-            <a href="{{ item.url }}">{{ item.text }}</a>
+            <a href="{{ item.url }}" {% if item.new_tab %}target="_blank"{% endif %}>{{ item.text }}</a>
         </li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
Hi @gicrisf,

First of all, thanks for providing this nice theme! I really appreciate it ❤️ . While trying it out, I think I have found a bug: 

In short, the `new_tab` setting for the **_social_** and **_connect_ _list_** is missing appropriate handling in the template. From what I understand, the fix is quite trivial, so I thought I'd send along a small PR.

Example Settings:
```toml
connect = [
    { url = "/blog", text = "Blog", new_tab = true },
    { url = "#", text = "Email", new_tab = false },
    { url = "#", text = "Newsletter", new_tab = false },
]
```

Side Question:

Could it be that the default/example template is missing the attribution part? I likely be able to convince the person I am doing the site for, to grab a license from you. Still, you might want to fix this default.

Best,
Nico
